### PR TITLE
refactor: API changes and switch to async await

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ build
 node_modules
 
 dist
+package-lock.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ jobs:
   include:
     - stage: check
       script:
-        - npx aegir commitlint --travis
         - npx aegir dep-check
         - npm run lint
 

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ pipe([1, 2, 3], stream, consume)
 
 ### Go
 
-### Attach muxer to a Connection
+#### Attach muxer to a Connection
 
 ```go
 muxedConn, err := muxer.Attach(conn, isListener)

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ If `err` is passed, no operation should be made in `stream`.
 
 `stream` interface our established Stream with the other endpoint, it must implement the [ReadWriteCloser](http://golang.org/pkg/io/#ReadWriteCloser).
 
-### Listen(wait/accept) a new incoming stream
+#### Listen(wait/accept) a new incoming stream
 
 ```go
 stream := muxedConn.Accept()

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ pipe(conn, muxer, conn) // conn is duplex connection to another peer
     ```
 * `maxMsgSize` - The maximum size in bytes the data field of multiplexed messages may contain (default 1MB)
 
-### `muxer.onStream`
+#### `muxer.onStream`
 
 Use this property as an alternative to passing `onStream` as an option to the `Muxer` constructor.
 

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ If `err` is passed, no operation should be made in `conn`.
 
 `muxedConn` interfaces our established Connection with the other endpoint, it must offer an interface to open a stream inside this connection and to receive incomming stream requests.
 
-### Dial(open/create) a new stream
+#### Dial(open/create) a new stream
 
 ```go
 stream, err := muxedConn.newStream()

--- a/README.md
+++ b/README.md
@@ -120,6 +120,12 @@ pipe(conn, muxer, conn) // conn is duplex connection to another peer
 
 Use this property as an alternative to passing `onStream` as an option to the `Muxer` constructor.
 
+```js
+const muxer = new Muxer()
+// ...later
+muxer.onStream = stream => { /* ... */ }
+```
+
 #### `const stream = muxer.newStream([options])`
 
 Initiate a new stream with the remote. Returns a [duplex stream](https://gist.github.com/alanshaw/591dc7dd54e4f99338a347ef568d6ee9#duplex-it).

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ test(common)
 
 ### JS
 
-A valid (read: that follows this abstraction) stream muxer, must implement the following API:
+A valid (one that follows this abstraction) stream muxer, must implement the following API:
 
 #### `const muxer = new Muxer([options])`
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-interface-stream-muxer
-=====================
+# interface-stream-muxer
 
 [![](https://img.shields.io/badge/made%20by-Protocol%20Labs-blue.svg?style=flat-square)](http://protocol.ai)
 [![](https://img.shields.io/badge/project-libp2p-yellow.svg?style=flat-square)](http://libp2p.io/)
@@ -15,7 +14,7 @@ The primary goal of this module is to enable developers to pick and swap their s
 
 Publishing a test suite as a module lets multiple modules all ensure compatibility since they use the same test suite.
 
-The API is presented with both Node.js and Go primitives, however, there is not actual limitations for it to be extended for any other language, pushing forward the cross compatibility and interop through diferent stacks.
+The API is presented with both Node.js and Go primitives, however, there is no actual limitations for it to be extended for any other language, pushing forward the cross compatibility and interop through different stacks.
 
 ## Lead Maintainer
 
@@ -37,7 +36,7 @@ Include this badge in your readme if you make a new module that uses interface-s
 
 ## Usage
 
-### Node.js
+### JS
 
 Install `interface-stream-muxer` as one of the dependencies of your project and as a test file. Then, using `mocha` (for JavaScript) or a test runner with compatible API, do:
 
@@ -45,11 +44,11 @@ Install `interface-stream-muxer` as one of the dependencies of your project and 
 const test = require('interface-stream-muxer')
 
 const common = {
-  setup (cb) {
-    cb(null, yourMuxer)
+  async setup () {
+    return yourMuxer
   },
-  teardown (cb) {
-    cb()
+  async teardown () {
+    // cleanup
   }
 }
 
@@ -63,12 +62,85 @@ test(common)
 
 ## API
 
-A valid (read: that follows this abstraction) stream muxer, must implement the following API.
+### JS
+
+A valid (read: that follows this abstraction) stream muxer, must implement the following API:
+
+#### `const muxer = new Muxer([options])`
+
+Create a new _duplex_ stream that can be piped together with a connection in order to allow multiplexed communications.
+
+e.g.
+
+```js
+const Muxer = require('your-muxer-module')
+const pipe = require('it-pipe')
+
+// Create a duplex muxer
+const muxer = new Muxer()
+
+// Use the muxer in a pipeline
+pipe(conn, muxer, conn) // conn is duplex connection to another peer
+```
+
+`options` is an optional `Object` that may have the following properties:
+
+* `onStream` - A function called when receiving a new stream from the remote. e.g.
+    ```js
+    // Receive a new stream on the muxed connection
+    const onStream = stream => {
+      // Read from this stream and write back to it (echo server)
+      pipe(
+        stream,
+        source => (async function * () {
+          for await (const data of source) yield data
+        })()
+        stream
+      )
+    }
+    const muxer = new Muxer({ onStream })
+    // ...
+    ```
+    **Note:** The `onStream` function can be passed in place of the `options` object. i.e.
+    ```js
+    new Mplex(stream => { /* ... */ })
+    ```
+* `signal` - An [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) which can be used to abort the muxer, _including_ all of it's multiplexed connections. e.g.
+    ```js
+    const controller = new AbortController()
+    const muxer = new Muxer({ signal: controller.signal })
+
+    pipe(conn, muxer, conn)
+
+    controller.abort()
+    ```
+* `maxMsgSize` - The maximum size in bytes the data field of multiplexed messages may contain (default 1MB)
+
+### `muxer.onStream`
+
+Use this property as an alternative to passing `onStream` as an option to the `Muxer` constructor.
+
+#### `const stream = muxer.newStream([options])`
+
+Initiate a new stream with the remote. Returns a [duplex stream](https://gist.github.com/alanshaw/591dc7dd54e4f99338a347ef568d6ee9#duplex-it).
+
+e.g.
+
+```js
+// Create a new stream on the muxed connection
+const stream = muxer.newStream()
+
+// Use this new stream like any other duplex stream:
+pipe([1, 2, 3], stream, consume)
+```
+
+### Go
 
 ### Attach muxer to a Connection
 
-- `JavaScript` muxedConn = muxer(conn, isListener)
-- `Go` muxedConn, err := muxer.Attach(conn, isListener)
+```go
+muxedConn, err := muxer.Attach(conn, isListener)
+```
 
 This method attaches our stream muxer to an instance of [Connection](https://github.com/libp2p/interface-connection/blob/master/src/connection.js) defined by [interface-connection](https://github.com/libp2p/interface-connection).
 
@@ -80,20 +152,20 @@ If `err` is passed, no operation should be made in `conn`.
 
 ### Dial(open/create) a new stream
 
-- `JavaScript` stream = muxedConn.newStream([function (err, stream)])
-- `Go` stream, err := muxedConn.newStream()
+```go
+stream, err := muxedConn.newStream()
+```
 
 This method negotiates and opens a new stream with the other endpoint.
 
 If `err` is passed, no operation should be made in `stream`.
 
-`stream` interface our established Stream with the other endpoint, it must implement the [Duplex pull-stream interface](https://pull-stream.github.io) in JavaScript or the [ReadWriteCloser](http://golang.org/pkg/io/#ReadWriteCloser) in Go.
+`stream` interface our established Stream with the other endpoint, it must implement the [ReadWriteCloser](http://golang.org/pkg/io/#ReadWriteCloser).
 
 ### Listen(wait/accept) a new incoming stream
 
-- `JavaScript` muxedConn.on('stream', function (stream) {})
-- `Go` stream := muxedConn.Accept()
+```go
+stream := muxedConn.Accept()
+```
 
 Each time a dialing peer initiates the new stream handshake, a new stream is created on the listening side.
-
-In JavaScript, the Event Emitter pattern is expected to be used in order to receive new incoming streams, while in Go, it expects to wait when Accept is called.

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "detect-node": "^2.0.4",
     "it-pair": "^1.0.0",
     "it-pipe": "^1.0.1",
-    "libp2p-tcp": "github:libp2p/js-libp2p-tcp#feat/async-await",
+    "libp2p-tcp": "github:libp2p/js-libp2p-tcp#feat/async-await2",
     "multiaddr": "^6.1.0",
     "p-limit": "^2.2.0",
     "streaming-iterables": "^4.1.0"

--- a/package.json
+++ b/package.json
@@ -33,6 +33,8 @@
   },
   "homepage": "https://github.com/libp2p/interface-stream-muxer",
   "dependencies": {
+    "abort-controller": "^3.0.0",
+    "abortable-iterator": "^2.1.0",
     "chai": "^4.2.0",
     "chai-checkmark": "^1.0.1",
     "detect-node": "^2.0.4",

--- a/package.json
+++ b/package.json
@@ -33,18 +33,18 @@
   },
   "homepage": "https://github.com/libp2p/interface-stream-muxer",
   "dependencies": {
-    "async": "^2.6.2",
     "chai": "^4.2.0",
     "chai-checkmark": "^1.0.1",
     "detect-node": "^2.0.4",
-    "libp2p-tcp": "~0.13.0",
-    "multiaddr": "^6.0.6",
-    "pull-generate": "^2.2.0",
-    "pull-pair": "^1.1.0",
-    "pull-stream": "^3.6.9"
+    "it-pair": "^1.0.0",
+    "it-pipe": "^1.0.1",
+    "libp2p-tcp": "github:libp2p/js-libp2p-tcp#feat/async-await",
+    "multiaddr": "^6.1.0",
+    "p-limit": "^2.2.0",
+    "streaming-iterables": "^4.1.0"
   },
   "devDependencies": {
-    "aegir": "^18.2.2"
+    "aegir": "^20.0.0"
   },
   "contributors": [
     "David Dias <daviddias.p@gmail.com>",

--- a/package.json
+++ b/package.json
@@ -40,8 +40,8 @@
     "detect-node": "^2.0.4",
     "it-pair": "^1.0.0",
     "it-pipe": "^1.0.1",
-    "libp2p-tcp": "github:libp2p/js-libp2p-tcp#feat/async-await2",
-    "multiaddr": "^6.1.0",
+    "libp2p-tcp": "^0.14.0",
+    "multiaddr": "^7.1.0",
     "p-limit": "^2.2.0",
     "streaming-iterables": "^4.1.0"
   },

--- a/src/close-test.js
+++ b/src/close-test.js
@@ -11,7 +11,7 @@ const { consume } = require('streaming-iterables')
 const Tcp = require('libp2p-tcp')
 const multiaddr = require('multiaddr')
 
-const mh = multiaddr('/ip4/127.0.0.1/tcp/10000')
+const mh = multiaddr('/ip4/127.0.0.1/tcp/0')
 
 async function closeAndWait (stream) {
   await pipe([], stream, consume)
@@ -44,7 +44,7 @@ module.exports = (common) => {
       })
 
       await tcpListener.listen(mh)
-      const dialerConn = await tcp.dial(mh)
+      const dialerConn = await tcp.dial(tcpListener.getAddrs()[0])
       const dialerMuxer = new Muxer()
 
       pipe(dialerConn, dialerMuxer, dialerConn)
@@ -61,11 +61,13 @@ module.exports = (common) => {
           try {
             await pipe(infiniteRandom, stream, consume)
           } catch (err) {
-            return expect(err).to.exist.mark()
+            return expect(err).to.exist()
           }
           throw new Error('stream did not throw')
         })()
       }))
+
+      console.log('ALL DONE!')
     })
 
     it('closing one of the muxed streams doesn\'t close others', (done) => {

--- a/src/close-test.js
+++ b/src/close-test.js
@@ -66,8 +66,6 @@ module.exports = (common) => {
           throw new Error('stream did not throw')
         })()
       }))
-
-      console.log('ALL DONE!')
     })
 
     it('closing one of the muxed streams doesn\'t close others', (done) => {

--- a/src/close-test.js
+++ b/src/close-test.js
@@ -19,7 +19,7 @@ async function closeAndWait (stream) {
 }
 
 const infiniteRandom = {
-  [Symbol.asyncIterator]: async function * () {
+  [Symbol.asyncIterator]: function * () {
     while (true) {
       yield new Promise(resolve => {
         setTimeout(() => resolve(Buffer.from(Math.random().toString())), 10)

--- a/src/mega-stress-test.js
+++ b/src/mega-stress-test.js
@@ -6,18 +6,12 @@ const spawn = require('./spawner')
 module.exports = (common) => {
   describe.skip('mega stress test', function () {
     this.timeout(100 * 200 * 1000)
-    let muxer
+    let Muxer
 
-    beforeEach((done) => {
-      common.setup((err, _muxer) => {
-        if (err) return done(err)
-        muxer = _muxer
-        done()
-      })
+    beforeEach(async () => {
+      Muxer = await common.setup()
     })
 
-    it('10000 messages of 10000 streams', (done) => {
-      spawn(muxer, 10000, 10000, done, 5000)
-    })
+    it('10,000 streams with 10,000 msg', () => spawn(Muxer, 10000, 10000, 5000))
   })
 }

--- a/src/spawner.js
+++ b/src/spawner.js
@@ -7,7 +7,7 @@ const pLimit = require('p-limit')
 const { collect, tap, consume } = require('streaming-iterables')
 
 module.exports = async (Muxer, nStreams, nMsg, limit) => {
-  const [ dialerSocket, listenerSocket ] = pair()
+  const [dialerSocket, listenerSocket] = pair()
   const { check, done } = marker((4 * nStreams) + (nStreams * nMsg))
 
   const msg = 'simple msg'
@@ -37,7 +37,7 @@ module.exports = async (Muxer, nStreams, nMsg, limit) => {
     check()
 
     const res = await pipe(
-      (async function * () {
+      (function * () {
         for (let i = 0; i < nMsg; i++) {
           // console.log('n', n, 'msg', i)
           yield new Promise(resolve => resolve(msg))

--- a/src/spawner.js
+++ b/src/spawner.js
@@ -1,92 +1,82 @@
 'use strict'
 
-const expect = require('chai').expect
+const { expect } = require('chai')
+const pair = require('it-pair/duplex')
+const pipe = require('it-pipe')
+const pLimit = require('p-limit')
+const { collect, tap, consume } = require('streaming-iterables')
 
-const pair = require('pull-pair/duplex')
-const pull = require('pull-stream')
-const generate = require('pull-generate')
-const each = require('async/each')
-const eachLimit = require('async/eachLimit')
-const setImmediate = require('async/setImmediate')
-
-module.exports = (muxer, nStreams, nMsg, done, limit) => {
-  const p = pair()
-  const dialerSocket = p[0]
-  const listenerSocket = p[1]
-
-  const check = marker((6 * nStreams) + (nStreams * nMsg), done)
+module.exports = async (Muxer, nStreams, nMsg, limit) => {
+  const [ dialerSocket, listenerSocket ] = pair()
+  const { check, done } = marker((4 * nStreams) + (nStreams * nMsg))
 
   const msg = 'simple msg'
 
-  const listener = muxer.listener(listenerSocket)
-  const dialer = muxer.dialer(dialerSocket)
-
-  listener.on('stream', (stream) => {
+  const listener = new Muxer(async stream => {
     expect(stream).to.exist // eslint-disable-line
     check()
-    pull(
+
+    await pipe(
       stream,
-      pull.through((chunk) => {
-        expect(chunk).to.exist // eslint-disable-line
-        check()
-      }),
-      pull.onEnd((err) => {
-        expect(err).to.not.exist // eslint-disable-line
-        check()
-        pull(pull.empty(), stream)
-      })
+      tap(chunk => check()),
+      consume
     )
+
+    check()
+    pipe([], stream)
   })
 
-  const numbers = []
-  for (let i = 0; i < nStreams; i++) {
-    numbers.push(i)
+  const dialer = new Muxer()
+
+  pipe(listenerSocket, listener, listenerSocket)
+  pipe(dialerSocket, dialer, dialerSocket)
+
+  const spawnStream = async n => {
+    const stream = dialer.newStream()
+    expect(stream).to.exist // eslint-disable-line
+    check()
+
+    const res = await pipe(
+      (async function * () {
+        for (let i = 0; i < nMsg; i++) {
+          // console.log('n', n, 'msg', i)
+          yield new Promise(resolve => resolve(msg))
+        }
+      })(),
+      stream,
+      collect
+    )
+
+    expect(res).to.be.eql([])
+    check()
   }
 
-  const spawnStream = (n, cb) => {
-    const stream = dialer.newStream((err) => {
-      expect(err).to.not.exist // eslint-disable-line
-      check()
-      expect(stream).to.exist // eslint-disable-line
-      check()
-      pull(
-        generate(0, (s, cb) => {
-          setImmediate(() => {
-            cb(s === nMsg ? true : null, msg, s + 1)
-          })
-        }),
-        stream,
-        pull.collect((err, res) => {
-          expect(err).to.not.exist // eslint-disable-line
-          check()
-          expect(res).to.be.eql([])
-          check()
-          cb()
-        })
-      )
-    })
-  }
+  const limiter = pLimit(limit || Infinity)
 
-  if (limit) {
-    eachLimit(numbers, limit, spawnStream, () => {})
-  } else {
-    each(numbers, spawnStream, () => {})
-  }
+  await Promise.all(
+    Array.from(Array(nStreams), (_, i) => limiter(() => spawnStream(i)))
+  )
+
+  return done
 }
 
-function marker (n, done) {
+function marker (n) {
+  let check
   let i = 0
-  return (err) => {
-    i++
+  const done = new Promise((resolve, reject) => {
+    check = err => {
+      i++
 
-    if (err) {
-      /* eslint-disable-next-line */
-      console.error('Failed after %s iterations', i)
-      return done(err)
-    }
+      if (err) {
+        /* eslint-disable-next-line */
+        console.error('Failed after %s iterations', i)
+        return reject(err)
+      }
 
-    if (i === n) {
-      done()
+      if (i === n) {
+        resolve()
+      }
     }
-  }
+  })
+  return { check, done }
 }

--- a/src/stress-test.js
+++ b/src/stress-test.js
@@ -5,63 +5,26 @@ const spawn = require('./spawner')
 
 module.exports = (common) => {
   describe('stress test', () => {
-    let muxer
+    let Muxer
 
-    beforeEach((done) => {
-      common.setup((err, _muxer) => {
-        if (err) return done(err)
-        muxer = _muxer
-        done()
-      })
+    beforeEach(async () => {
+      Muxer = await common.setup()
     })
 
-    it('1 stream with 1 msg', (done) => {
-      spawn(muxer, 1, 1, done)
-    })
-
-    it('1 stream with 10 msg', (done) => {
-      spawn(muxer, 1, 10, done)
-    })
-
-    it('1 stream with 100 msg', (done) => {
-      spawn(muxer, 1, 100, done)
-    })
-
-    it('10 streams with 1 msg', (done) => {
-      spawn(muxer, 10, 1, done)
-    })
-
-    it('10 streams with 10 msg', (done) => {
-      spawn(muxer, 10, 10, done)
-    })
-
-    it('10 streams with 100 msg', (done) => {
-      spawn(muxer, 10, 100, done)
-    })
-
-    it('100 streams with 1 msg', (done) => {
-      spawn(muxer, 100, 1, done)
-    })
-
-    it('100 streams with 10 msg', (done) => {
-      spawn(muxer, 100, 10, done)
-    })
-
-    it('100 streams with 100 msg', (done) => {
-      spawn(muxer, 100, 100, done)
-    })
-
-    it('1000 streams with 1 msg', (done) => {
-      spawn(muxer, 1000, 1, done)
-    })
-
-    it('1000 streams with 10 msg', (done) => {
-      spawn(muxer, 1000, 10, done)
-    })
-
-    it('1000 streams with 100 msg', function (done) {
-      this.timeout(80 * 1000)
-      spawn(muxer, 1000, 100, done)
+    it('1 stream with 1 msg', () => spawn(Muxer, 1, 1))
+    it('1 stream with 10 msg', () => spawn(Muxer, 1, 10))
+    it('1 stream with 100 msg', () => spawn(Muxer, 1, 100))
+    it('10 streams with 1 msg', () => spawn(Muxer, 10, 1))
+    it('10 streams with 10 msg', () => spawn(Muxer, 10, 10))
+    it('10 streams with 100 msg', () => spawn(Muxer, 10, 100))
+    it('100 streams with 1 msg', () => spawn(Muxer, 100, 1))
+    it('100 streams with 10 msg', () => spawn(Muxer, 100, 10))
+    it('100 streams with 100 msg', () => spawn(Muxer, 100, 100))
+    it('1000 streams with 1 msg', () => spawn(Muxer, 1000, 1))
+    it('1000 streams with 10 msg', () => spawn(Muxer, 1000, 10))
+    it('1000 streams with 100 msg', function () {
+      this.timeout(30 * 1000)
+      return spawn(Muxer, 1000, 100)
     })
   })
 }


### PR DESCRIPTION
For implementation of this API, see https://github.com/libp2p/js-libp2p-mplex/pull/94

## New API

### `const muxer = new Muxer([options])`

Create a new _duplex_ stream that can be piped together with a connection in order to allow multiplexed communications.

e.g.

```js
const Muxer = require('your-muxer-module')
const pipe = require('it-pipe')

// Create a duplex muxer
const muxer = new Muxer()

// Use the muxer in a pipeline
pipe(conn, muxer, conn) // conn is duplex connection to another peer
```

`options` is an optional `Object` that may have the following properties:

* `onStream` - A function called when receiving a new stream from the remote. e.g.
    ```js
    // Receive a new stream on the muxed connection
    const onStream = stream => {
      // Read from this stream and write back to it (echo server)
      pipe(
        stream,
        source => (async function * () {
          for await (const data of source) yield data
        })()
        stream
      )
    }
    const muxer = new Muxer({ onStream })
    // ...
    ```
    **Note:** The `onStream` function can be passed in place of the `options` object. i.e.
    ```js
    new Muxer(stream => { /* ... */ })
    ```
* `signal` - An [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) which can be used to abort the muxer, _including_ all of it's multiplexed connections. e.g.
    ```js
    const controller = new AbortController()
    const muxer = new Muxer({ signal: controller.signal })

    pipe(conn, muxer, conn)

    controller.abort()
    ```
* `maxMsgSize` - The maximum size in bytes the data field of multiplexed messages may contain (default 1MB)

### `muxer.onStream`

Use this property as an alternative to passing `onStream` as an option to the `Muxer` constructor.

```js
const muxer = new Muxer()
// ...later
muxer.onStream = stream => { /* ... */ }
```

### `const stream = muxer.newStream([options])`

Initiate a new stream with the remote. Returns a [duplex stream](https://gist.github.com/alanshaw/591dc7dd54e4f99338a347ef568d6ee9#duplex-it).

e.g.

```js
// Create a new stream on the muxed connection
const stream = muxer.newStream()

// Use this new stream like any other duplex stream:
pipe([1, 2, 3], stream, consume)
```

## Notable changes

### Buffer list

Data received by multiplexed streams are expected to be instances of [`BufferList`](https://www.npmjs.com/package/bl) not [`Buffer`](https://www.npmjs.com/package/buffer). This is to avoid unnecessary (and slow) buffer copies in some cases.

### No events

Muxer implementations are not event emitters, nor are any of the streams they receive or create.

### No distinction between listener/dialer

Just create a `new Muxer`. If you don't want to listen then don't pass an `onStream`. If you don't want to dial then don't call `newStream`.

### Does not automatically pipe itself to anything

Muxer instances are [duplex streams]((https://gist.github.com/alanshaw/591dc7dd54e4f99338a347ef568d6ee9#duplex-it)). If you want to use them, you now do the piping yourself. This is in contrast to `js-libp2p-mplex` or `pull-mplex` where you pass a `Connection` which is automatically piped together with the muxer for you.

This is a simplification to give the user of the muxer more power over what happens when errors occur in the stream. i.e. the user can catch an error and re-establish the connection for example.

### Lazy by default

It's not documented anywhere, but the `lazy` option seen in `js-libp2p-mplex` or `pull-mplex` is no longer applicable. I do not know if it was ever used (it is `false` by default)!

Setting `lazy: true` in `js-libp2p-mplex`/`pull-mplex` simply means that the `NEW_STREAM` message is sent to the other side automatically before you start to send your data, not immediately when the stream is created. FYI, `NEW_STREAM` instructs the _other side_ to open a new multiplexed stream so it can start receiving the data you want to send.

So, like this (in `pull-mplex`/`js-libp2p-mplex`):

```js
const s = muxer.newStream({ lazy: false })
// NEW_STREAM is now sent to the other side
// Later...
pull(pull.values([1, 2, 3]), s, pull.onEnd(() => console.log('done')))

// VS

const s = muxer.newStream({ lazy: true })
// Later...
pull(pull.values([1, 2, 3]), s, pull.onEnd(() => console.log('done')))
// NEW_STREAM is now sent to the other side automatically before 1
```

Same code with the new muxer API:

```js
const s = muxer.newStream()
// Later...
await pipe([1, 2, 3], s, consume)
// NEW_STREAM is now sent to the other side automatically before 1
console.log('done')
```

That is to say that in this new API the streams are "lazy" by default and only send the `NEW_STREAM` message to the other side when the stream is hooked up to a pipeline and data is about to be sent. So, if you don't want to open the stream on the other side, don't pipe any data into the stream.

There's no real reason to _not_ be lazy. There's no use case where we will open a new muxed stream and start to receive data without sending something first. i.e. you would never do this:

```js
const s = muxer.newStream()
await pipe(s, consume)
```

...and you shouldn't do this anyway because it'll leak resources. The other side will "close" the stream (the source) when it has sent everything and the stream will be left half open because nothing has closed the sink side of the duplex.

If you REALLY needed to do this you'd do the following:

```js
const s = muxer.newStream()
await pipe([], s, consume)

// OR

const s = muxer.newStream()
await pipe(s, consume)
// Not ideal because although this would close the sink side it'll cause a RESET
// message to be sent to the other side.
s.abort()
```