### PR TITLE
chore: add deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+⛔️ DEPRECATED: interface-stream-muxer is now included in [libp2p-interfaces](https://github.com/libp2p/js-interfaces)
+======
+
 # interface-stream-muxer
 
 [![](https://img.shields.io/badge/made%20by-Protocol%20Labs-blue.svg?style=flat-square)](http://protocol.ai)


### PR DESCRIPTION
In the context of [libp2p/js-libp2p#383](https://github.com/libp2p/js-libp2p/issues/383), a deprecation notice is added.

Needs:

- [ ] npm deprecation notice

After merged, the repo must be archived (I do not have permissions to do it)